### PR TITLE
Move copy right information after xml declaration

### DIFF
--- a/Sdk.props
+++ b/Sdk.props
@@ -1,7 +1,3 @@
-<!-- Copyright (c) Microsoft Corporation. All rights reserved.
-       Licensed under the MIT license.
--->
-  
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
@@ -12,6 +8,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT license.
 ***********************************************************************************************
 -->
 

--- a/Sdk.targets
+++ b/Sdk.targets
@@ -1,7 +1,3 @@
-<!-- Copyright (c) Microsoft Corporation. All rights reserved.
-       Licensed under the MIT license.
--->
-
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
@@ -12,6 +8,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT license.
 ***********************************************************************************************
 -->
 


### PR DESCRIPTION
For XML the first line has to be the xml header.
Or it will break dotnet/cli CI build.