### PR TITLE
Documentation reference update

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The current tooling supports building and debugging .NET Framework web/console a
 
 # Documentation
 
-- [Put a .NET Core App in a Container with the new Docker Tools for Visual Studio ](https://blogs.msdn.microsoft.com/webdev/2016/11/16/new-docker-tools-for-visual-studio/)
+- [Container Tools in Visual Studio](https://docs.microsoft.com/en-us/visualstudio/containers/overview?view=vs-2019)
 
 # Contributing
 


### PR DESCRIPTION
The reference to a blog article was out of date as it was based on a 2017 RC version.   I think it should point to the official docs.